### PR TITLE
Small typo in ObjectsGS.py fixed

### DIFF
--- a/objectsGS.py
+++ b/objectsGS.py
@@ -660,7 +660,7 @@ class RGlyph(BaseGlyph):
 		# 	anchor.setChanged(False)
 		# self.setChanged(False)
 	def _get_box(self):
-		bounds = self._layer.bounds()
+		bounds = self._layer.bounds
 		#print "__bounds", bounds.origin
 		bounds = (int(round(NSMinX(bounds))), int(round(NSMinY(bounds))), int(round(NSMaxX(bounds))), int(round(NSMaxY(bounds))))
 		return bounds


### PR DESCRIPTION
Hi, I found a small typo in RGlyph._get_box, and fixed it ...
