### PR TITLE
If lib is empty, return an empty dict instead of None

### DIFF
--- a/objectsGS.py
+++ b/objectsGS.py
@@ -207,7 +207,10 @@ class RFont(BaseFont):
 		self._document.close()
 	
 	def _get_lib(self):
-		return self._font.userData.objectForKey_("org.robofab.ufoLib")
+		_lib = self._font.userData.objectForKey_("org.robofab.ufoLib")
+		if _lib is None:
+			return {}
+		return _lib
 	
 	def _set_lib(self, obj):
 		self._font.userData.setObject_forKey_(obj, "org.robofab.ufoLib")


### PR DESCRIPTION
I'm suggesting to return a dict in any case when accessing the lib. This would be more consistent with the way defcon handles it.