### PR TITLE
make import/export FontLab macros work on Windows as well

### DIFF
--- a/Glyphs Export.py
+++ b/Glyphs Export.py
@@ -559,8 +559,14 @@ def writeFeatures(font, Dict):
 def GetSaveFile(message=None, ProposedFileName=None, filetypes=None):
 	if filetypes is None:
 		filetypes = []
-	from Foundation import NSSavePanel
-	from AppKit import NSOKButton
+	try:
+		from Foundation import NSSavePanel
+		from AppKit import NSOKButton
+	except ImportError:
+		assert len(filetypes) == 1
+		filetype = filetypes[0]
+		ProposedFileName = ProposedFileName if ProposedFileName else ""
+		return fl.GetFileName(0, "", ProposedFileName, "%s file|*.%s" % (filetype.capitalize(), filetype))
 	Panel = NSSavePanel.savePanel().retain()
 	if message is not None:
 		Panel.setTitle_(message)
@@ -588,7 +594,7 @@ def main():
 		if FamilyName is not None:
 			FamilyName = FamilyName + ".glyphs"
 		path = GetSaveFile(message="Please select a .glyphs file", ProposedFileName=FamilyName, filetypes=["glyphs"])
-		if path is None:
+		if not path:
 			return
 	path = os.path.splitext(path)[0]
 	path = path+".glyphs"


### PR DESCRIPTION
There's no reason for the two Import/Export Fontlab macros to be Mac-only.

The built-in `plistlib` module can parse XML property lists. And the [glyphs2ufo](https://github.com/googlei18n/glyphs2ufo) library can parse .glyphs files encoded in plain-text plist format.

For the Open/Save dialogs we can use FontLab built-in dialogs.

The "GlyphData.xml" file contained inside the Glyphs.app bundle is now also available from https://github.com/schriftgestalt/GlyphsInfo. So, when running on Windows, one can specify the full path to GlyphData.xml file with the `GLYPHS_INFO_PATH` variable at the top of "Glyphs Import.py" macro.

The `weightCodes` mapping should not change very often, so we could hard-code it in here, instead of reading it off the "weights.plist" file inside Glyphs.app's resources.

PTAL, thanks.

