### PR TITLE
[Glyphs Import] use cElementTree if available

### DIFF
--- a/Glyphs Import.py
+++ b/Glyphs Import.py
@@ -344,7 +344,11 @@ def applicationSupportFolder(appname=u"Glyphs"):
 
 def parseGlyphDataFile(Path):
 	try:
-		from xml.etree import ElementTree as ET
+		try:
+			from xml.etree import cElementTree as ET
+		except ImportError:
+			from xml.etree import ElementTree as ET
+
 		element = ET.parse(Path)
 		
 		for subelement in element.getiterator():


### PR DESCRIPTION
The C implementation of ElementTree is in Python's standard library since version 2.5.
It is 20x faster than the pure Python one.