### PR TITLE
[Glyphs Import] don't require glyphs2ufo to parse .glyphs file on OS X

### DIFF
--- a/Glyphs Import.py
+++ b/Glyphs Import.py
@@ -979,9 +979,9 @@ def readGlyphsFile(filePath):
 			from plistlib import readPlistFromString
 			GlyphsDoc = readPlistFromString(data)
 		else:
-			# use glyphs2ufo's Parser for ASCII plist.
-			# Download it from: https://github.com/googlei18n/glyphs2ufo
-			from glyphs2ufo.parser import Parser
+			# use glyphsLib's Parser for ASCII plist.
+			# Download it from: https://github.com/googlei18n/glyphsLib
+			from glyphsLib.parser import Parser
 			GlyphsDoc = Parser(dict_type=dict).parse(data)
 	else:
 		# on OS X, use NSDictionary

--- a/Glyphs Import.py
+++ b/Glyphs Import.py
@@ -967,15 +967,32 @@ def setLegacyNames(Font):
 	
 def readGlyphsFile(filePath):
 	print "Import Glyphs File"
-	with open(filePath, 'rb') as f:
-		data = f.read()
-
-	if data.startswith("<?xml"):
-		from plistlib import readPlistFromString
-		GlyphsDoc = readPlistFromString(data)
+	pool = None
+	try:
+		from Foundation import NSAutoreleasePool, NSDictionary
+	except ImportError:
+		# on Windows, PyObjC is not available
+		with open(filePath, 'rb') as f:
+			data = f.read()
+		if data.startswith("<?xml"):
+			# use the built-in plistlib module for XML plist
+			from plistlib import readPlistFromString
+			GlyphsDoc = readPlistFromString(data)
+		else:
+			# use glyphs2ufo's Parser for ASCII plist.
+			# Download it from: https://github.com/googlei18n/glyphs2ufo
+			from glyphs2ufo.parser import Parser
+			GlyphsDoc = Parser(dict_type=dict).parse(data)
 	else:
-		from glyphs2ufo.parser import Parser
-		GlyphsDoc = Parser(dict_type=dict).parse(data)
+		# on OS X, use NSDictionary
+		pool = NSAutoreleasePool.alloc().init()
+		GlyphsDoc = NSDictionary.alloc().initWithContentsOfFile_(filePath)
+
+	if not GlyphsDoc:
+		print "Could not load .glyphs file."
+		if pool:
+			pool.drain()
+		return
 
 	from FL import fl, Font
 	folder, base = os.path.split(filePath)
@@ -997,6 +1014,8 @@ def readGlyphsFile(filePath):
 	
 	fl.UpdateFont()
 	f.modified = 0
+	if pool:
+		pool.drain()
 
 
 def GetFile(message=None, filetypes = None, selectFolders = True, selectFiles = True):


### PR DESCRIPTION
Better keep using `Foundation.NSDictionary` when that is available,
instead of requiring OS X users to install glyphs2ufo when importing .glyphs files.