### PR TITLE
[Glyphs Import] fix "TypeError: 'NoneType' object has no attribute '__getitem__'"

### DIFF
--- a/Glyphs Import.py
+++ b/Glyphs Import.py
@@ -511,12 +511,11 @@ def readGlyphs(Font, Dict):
 		
 		for masterIndex in range(MasterCount):
 			FontMaster = FontMasters[masterIndex]
-			Layer = None
-			try:
-				for Layer in GlyphDict["layers"]:
-					if Layer["layerId"] == FontMaster["id"]:
-						break
-			except:
+			for Layer in GlyphDict["layers"]:
+				if Layer["layerId"] == FontMaster["id"]:
+					break
+			else:
+				# 'master' layer not found, skip
 				continue
 			ShiftNodes = 0
 			if isNonSpacingMark:


### PR DESCRIPTION
I have come across some .glyphs files in which some of the glyphs have their `layers` attribute completely empty, despite the font contains two or more masters.

When this occurs, the Fontlab "Glyphs Import" script raises the following error:

```
Traceback (most recent call last):
  File "<string>", line 1065, in <module>
  File "<string>", line 1056, in main
  File "<string>", line 1014, in readGlyphsFile
  File "<string>", line 508, in readGlyphs
TypeError: 'NoneType' object has no attribute '__getitem__'
```

The  `Layer` variable is initially set to None. If `GlyphDict["layers"]` is empty, the `Layer` variable is still None, so the subsequent `Layer['width']` fails with `TypeError`.

This PR is an attempt to fix this issue.

It's worth noting that I was not able to replicate this "glyph-without-layers" behaviour myself. Every time I create a new glyph, this always comes with a minimum set of layers, each corresponding to one of the masters. I can add new layers to the glyph, but I can't delete the default ones (rightly so, I believe).
