### PR TITLE
Glyphs Import: glyphsLib.Parser no longer takes 'dict_type' kwarg

### DIFF
--- a/Glyphs Import.py
+++ b/Glyphs Import.py
@@ -1007,7 +1007,7 @@ def readGlyphsFile(filePath):
 			# use glyphsLib's Parser for ASCII plist.
 			# Download it from: https://github.com/googlei18n/glyphsLib
 			from glyphsLib.parser import Parser
-			GlyphsDoc = Parser(dict_type=dict).parse(data)
+			GlyphsDoc = Parser().parse(data)
 	else:
 		# on OS X, use NSDictionary
 		pool = NSAutoreleasePool.alloc().init()


### PR DESCRIPTION
passing a 'dict_type' will raise an error, as the keyword argument is no longer recognised.

`glyphsLib.Parser()` now defaults to an `OrderedDict`:

https://github.com/googlei18n/glyphsLib/commit/4fa2ddbe4379adab1998e49705434a4b2897a5a5